### PR TITLE
Avoid double scaling by GNOME

### DIFF
--- a/run_scaled
+++ b/run_scaled
@@ -74,4 +74,4 @@ DISPLAYNUM=:`shuf -i 10000-99999999 -n 1`
 ESCAPED_PARAMS=`printf '%q ' "$@"`
 xpra start "$DISPLAYNUM" --xvfb="Xvfb +extension Composite -screen 0 ${UNSCALED_RESOLUTION}x24+32 -nolisten tcp -noreset  -auth \$XAUTHORITY" --env=GDK_SCALE=1 --env=GDK_DPI_SCALE=1 --start-child="$ESCAPED_PARAMS" --exit-with-children
 sleep "$SLEEPTIME"
-xpra attach "$DISPLAYNUM" "--desktop-scaling=$SCALING_FACTOR" "--opengl=$USE_OPENGL" $PERFORMANCE_OPTIONS || xpra stop "$DISPLAYNUM"
+GDK_SCALE=1 xpra attach "$DISPLAYNUM" "--desktop-scaling=$SCALING_FACTOR" "--opengl=$USE_OPENGL" $PERFORMANCE_OPTIONS || xpra stop "$DISPLAYNUM"


### PR DESCRIPTION
When GDK_SCALE is set to anything but 1, xpra will be scaled twice (in addition to the scaling it has doe it self).
This is probably due to the gtk code in xpra not being DPI aware, but the gtk backend deciding it should scale anyways.